### PR TITLE
Add decryption flow with timed cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,67 +1,44 @@
 <!DOCTYPE html>
-<html>
-  <head>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
     <title>{{.Title}}</title>
-    <style>
-      body {
-        font-family: sans-serif;
-        margin: 2em;
-        background-color: #333;
-      }
-      h1 {
-        color: #333;
-      }
-      form {
-        margin-top: 1em;
-        padding: 1em;
-        border: 1px solid #ccc;
-        border-radius: 5px;
-        background-color: #f9f9f9;
-      }
-      input[type="file"] {
-        margin-bottom: 1em;
-      }
-      input[type="submit"] {
-        padding: 0.5em 1em;
-        background-color: #007bff;
-        color: white;
-        border: none;
-        border-radius: 3px;
-        cursor: pointer;
-      }
-      input[type="submit"]:hover {
-        background-color: #0056b3;
-      }
-      .message {
-        margin-top: 1em;
-        padding: 0.8em;
-        border-radius: 4px;
-      }
-      .success {
-        background-color: #d4edda;
-        color: #155724;
-        border-color: #c3e6cb;
-      }
-      .error {
-        background-color: #f8d7da;
-        color: #721c24;
-        border-color: #f5c6cb;
-      }
-    </style>
-  </head>
-  <body>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
     <h1>{{.Header}}</h1>
-
     <form action="/file/upload" method="post" enctype="multipart/form-data">
-      <label for="file">Выберите файл:</label><br />
-      <input type="file" name="file" id="file" /><br />
-      <input type="submit" value="Загрузить файл" />
+        <label for="file">Выберите файл:</label><br>
+        <input type="file" name="file" id="file"><br>
+        <input type="submit" value="Загрузить файл">
     </form>
+
+    <h2>Дешифровка</h2>
+    <form action="/file/decrypt" method="post">
+        <label for="enc">Имя зашифрованного файла (.enc):</label><br>
+        <input type="text" name="filename" id="enc"><br>
+        <label for="key">Ключ (base64):</label><br>
+        <input type="text" name="key" id="key"><br>
+        <button type="submit">Скачать расшифрованный файл</button>
+    </form>
+
+    <h2>Зашифрованные файлы</h2>
+    <table id="fileTable">
+        <tr><th>Файл</th><th>Удаление через</th></tr>
+        {{range .Files}}
+        <tr data-expires="{{.ExpiresAt.Unix}}">
+            <td>{{.Name}}</td>
+            <td class="countdown"></td>
+        </tr>
+        {{end}}
+    </table>
 
     {{if .Message}}
     <div class="message {{if .IsError}}error{{else}}success{{end}}">
-      {{.Message}}
+        {{.Message}}
     </div>
     {{end}}
-  </body>
+
+    <script src="/static/script.js"></script>
+</body>
 </html>

--- a/main.go
+++ b/main.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -25,10 +27,9 @@ import (
 	4.ui
 */
 
-var 
-(
-    tmpl *template.Template
-    host string = "localhost:8000"
+var (
+	tmpl *template.Template
+	host string = "localhost:8000"
 )
 
 type IndexData struct {
@@ -36,17 +37,21 @@ type IndexData struct {
 	Header  string
 	Message string
 	IsError bool
+	Files   []EncryptedFile
+}
+
+type EncryptedFile struct {
+	Name      string
+	ExpiresAt time.Time
 }
 
 type EncryptionResult struct {
-    EncryptedData string `json:"encrypted_data"`
-    Nonce         string `json:"nonce"`
-    Key           string `json:"key"`
+	EncryptedData string `json:"encrypted_data"`
+	Nonce         string `json:"nonce"`
+	Key           string `json:"key"`
 }
 
-
-
-func init(){
+func init() {
 	tmpl = template.Must(template.ParseFiles("index.html"))
 
 	os.MkdirAll("./uploads", 0755)
@@ -55,63 +60,97 @@ func init(){
 
 // создает случайный 32-байтовый ключ
 func generateRandomKey() ([]byte, error) {
-    key := make([]byte, 32)
-    _, err := rand.Read(key)
-    return key, err
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	return key, err
 }
 
 // encryptData шифрует данные с использованием AES-256-GCM
 func encryptData(data []byte, key []byte) ([]byte, []byte, error) {
-    block, err := aes.NewCipher(key)
-    if err != nil {
-        return nil, nil, err
-    }
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, nil, err
+	}
 
-    gcm, err := cipher.NewGCM(block)
-    if err != nil {
-        return nil, nil, err
-    }
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, nil, err
+	}
 
-    nonce := make([]byte, gcm.NonceSize())
-    if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-        return nil, nil, err
-    }
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, nil, err
+	}
 
-    ciphertext := gcm.Seal(nil, nonce, data, nil)
-    
-    return ciphertext, nonce, nil
+	ciphertext := gcm.Seal(nil, nonce, data, nil)
+
+	return ciphertext, nonce, nil
 }
 
 func encryptFile(inputPath, outputPath string, key []byte) ([]byte, error) {
-    data, err := os.ReadFile(inputPath)
-    if err != nil {
-        return nil, err
-    }
+	data, err := os.ReadFile(inputPath)
+	if err != nil {
+		return nil, err
+	}
 
-    ciphertext, nonce, err := encryptData(data, key)
-    if err != nil {
-        return nil, err
-    }
+	ciphertext, nonce, err := encryptData(data, key)
+	if err != nil {
+		return nil, err
+	}
 
-    encryptedFile := struct {
-        Data  []byte `json:"data"`
-        Nonce []byte `json:"nonce"`
-    }{
-        Data:  ciphertext,
-        Nonce: nonce,
-    }
+	encryptedFile := struct {
+		Data  []byte `json:"data"`
+		Nonce []byte `json:"nonce"`
+	}{
+		Data:  ciphertext,
+		Nonce: nonce,
+	}
 
-    jsonData, err := json.Marshal(encryptedFile)
-    if err != nil {
-        return nil, err
-    }
+	jsonData, err := json.Marshal(encryptedFile)
+	if err != nil {
+		return nil, err
+	}
 
-    err = os.WriteFile(outputPath, jsonData, 0644)
-    if err != nil {
-        return nil, err
-    }
+	err = os.WriteFile(outputPath, jsonData, 0644)
+	if err != nil {
+		return nil, err
+	}
 
-    return nonce, nil
+	return nonce, nil
+}
+
+func scheduleDeletion(path string, d time.Duration) {
+	time.AfterFunc(d, func() { os.Remove(path) })
+}
+
+// decryptData расшифровывает данные используя AES-256-GCM
+func decryptData(ciphertext, nonce, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	return gcm.Open(nil, nonce, ciphertext, nil)
+}
+
+func decryptFile(encPath string, key []byte) ([]byte, error) {
+	data, err := os.ReadFile(encPath)
+	if err != nil {
+		return nil, err
+	}
+	var ef struct {
+		Data  []byte `json:"data"`
+		Nonce []byte `json:"nonce"`
+	}
+	if err := json.Unmarshal(data, &ef); err != nil {
+		return nil, err
+	}
+	return decryptData(ef.Data, ef.Nonce, key)
 }
 
 func main() {
@@ -119,76 +158,116 @@ func main() {
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 
+	r.Handle("/static/*", http.StripPrefix("/static/", http.FileServer(http.Dir("static"))))
+
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		entries, _ := os.ReadDir("./encrypted")
+		files := make([]EncryptedFile, 0, len(entries))
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			info, err := e.Info()
+			if err != nil {
+				continue
+			}
+			files = append(files, EncryptedFile{
+				Name:      e.Name(),
+				ExpiresAt: info.ModTime().Add(15 * time.Minute),
+			})
+		}
 		data := IndexData{
 			Title:  "Загрузка файла",
 			Header: "Загрузить ваш файл",
+			Files:  files,
 		}
-		err := tmpl.Execute(w, data)
-		if err != nil {
+		if err := tmpl.Execute(w, data); err != nil {
 			http.Error(w, fmt.Sprintf("Ошибка при рендеринге шаблона: %v", err), http.StatusInternalServerError)
 			return
 		}
 	})
 
-    r.Post("/file/upload", func(w http.ResponseWriter, r *http.Request) {
-        // Парсим форму (10 MB max)
-        err := r.ParseMultipartForm(10 << 20)
-        if err != nil {
-            http.Error(w, fmt.Sprintf("Failed to parse multipart form: %v", err), http.StatusBadRequest)
-            return
-        }
+	r.Post("/file/upload", func(w http.ResponseWriter, r *http.Request) {
+		// Парсим форму (10 MB max)
+		err := r.ParseMultipartForm(10 << 20)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to parse multipart form: %v", err), http.StatusBadRequest)
+			return
+		}
 
-        file, fileHeader, err := r.FormFile("file")
-        if err != nil {
-            http.Error(w, fmt.Sprintf("Failed to get file: %v", err), http.StatusBadRequest)
-            return
-        }
-        defer file.Close()
-        
-        var key []byte
- 
+		file, fileHeader, err := r.FormFile("file")
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to get file: %v", err), http.StatusBadRequest)
+			return
+		}
+		defer file.Close()
+
+		var key []byte
+
 		key, err = generateRandomKey()
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Failed to generate key: %v", err), http.StatusInternalServerError)
 			return
 		}
-        
-        originalPath := filepath.Join("./uploads", fileHeader.Filename)
-        dst, err := os.Create(originalPath)
-        if err != nil {
-            http.Error(w, fmt.Sprintf("Failed to create file on server: %v", err), http.StatusInternalServerError)
-            return
-        }
-        defer dst.Close()
 
-        if _, err := io.Copy(dst, file); err != nil {
-            http.Error(w, fmt.Sprintf("Failed to copy file content: %v", err), http.StatusInternalServerError)
-            return
-        }
+		originalPath := filepath.Join("./uploads", fileHeader.Filename)
+		dst, err := os.Create(originalPath)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to create file on server: %v", err), http.StatusInternalServerError)
+			return
+		}
+		defer dst.Close()
 
-        encryptedPath := filepath.Join("./encrypted", fileHeader.Filename+".enc")
-        nonce, err := encryptFile(originalPath, encryptedPath, key)
-        if err != nil {
-            http.Error(w, fmt.Sprintf("Failed to encrypt file: %v", err), http.StatusInternalServerError)
-            return
-        }
+		if _, err := io.Copy(dst, file); err != nil {
+			http.Error(w, fmt.Sprintf("Failed to copy file content: %v", err), http.StatusInternalServerError)
+			return
+		}
 
-        os.Remove(originalPath)
+		encryptedPath := filepath.Join("./encrypted", fileHeader.Filename+".enc")
+		nonce, err := encryptFile(originalPath, encryptedPath, key)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to encrypt file: %v", err), http.StatusInternalServerError)
+			return
+		}
 
-        response := map[string]interface{}{
-            "message":        "File uploaded and encrypted successfully!",
-            "filename":       fileHeader.Filename,
-            "encrypted_file": fileHeader.Filename + ".enc",
-            "size":          fmt.Sprintf("%d bytes", fileHeader.Size),
-            "key":           base64.StdEncoding.EncodeToString(key),
-            "nonce":         base64.StdEncoding.EncodeToString(nonce),
-        }
+		os.Remove(originalPath)
+		scheduleDeletion(encryptedPath, 15*time.Minute)
 
-        w.Header().Add("Content-Type", "application/json")
-        json.NewEncoder(w).Encode(response)
-    })
+		response := map[string]interface{}{
+			"message":        "File uploaded and encrypted successfully!",
+			"filename":       fileHeader.Filename,
+			"encrypted_file": fileHeader.Filename + ".enc",
+			"size":           fmt.Sprintf("%d bytes", fileHeader.Size),
+			"key":            base64.StdEncoding.EncodeToString(key),
+			"nonce":          base64.StdEncoding.EncodeToString(nonce),
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	})
+
+	r.Post("/file/decrypt", func(w http.ResponseWriter, r *http.Request) {
+		filename := r.FormValue("filename")
+		keyB64 := r.FormValue("key")
+		if filename == "" || keyB64 == "" {
+			http.Error(w, "filename and key required", http.StatusBadRequest)
+			return
+		}
+		key, err := base64.StdEncoding.DecodeString(keyB64)
+		if err != nil {
+			http.Error(w, "invalid key", http.StatusBadRequest)
+			return
+		}
+		encPath := filepath.Join("./encrypted", filename)
+		data, err := decryptFile(encPath, key)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to decrypt: %v", err), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Disposition", "attachment; filename="+strings.TrimSuffix(filename, ".enc"))
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write(data)
+	})
 
 	fmt.Printf("Server is running on http://%s/", host)
-	http.ListenAndServe(host, r)
-}
+	http.ListenAndServe(host, r)}

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,17 @@
+function updateCountdown() {
+    document.querySelectorAll('#fileTable tr[data-expires]').forEach(row => {
+        const expires = parseInt(row.getAttribute('data-expires')) * 1000;
+        const diff = expires - Date.now();
+        const cell = row.querySelector('.countdown');
+        if (diff <= 0) {
+            cell.textContent = 'expired';
+        } else {
+            let sec = Math.floor(diff / 1000);
+            const min = Math.floor(sec / 60);
+            sec = sec % 60;
+            cell.textContent = `${min}:${sec.toString().padStart(2, '0')}`;
+        }
+    });
+}
+setInterval(updateCountdown, 1000);
+updateCountdown();

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,52 @@
+body {
+    font-family: sans-serif;
+    margin: 2em;
+    background-color: #f9f9f9;
+}
+h1 {
+    color: #333;
+}
+form {
+    margin-top: 1em;
+    padding: 1em;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    background-color: #fff;
+}
+input[type="file"] {
+    margin-bottom: 1em;
+}
+input[type="submit"], button {
+    padding: 0.5em 1em;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+}
+input[type="submit"]:hover, button:hover {
+    background-color: #0056b3;
+}
+.message {
+    margin-top: 1em;
+    padding: 0.8em;
+    border-radius: 4px;
+}
+.success {
+    background-color: #d4edda;
+    color: #155724;
+    border-color: #c3e6cb;
+}
+.error {
+    background-color: #f8d7da;
+    color: #721c24;
+    border-color: #f5c6cb;
+}
+#fileTable {
+    margin-top: 1em;
+    border-collapse: collapse;
+}
+#fileTable th, #fileTable td {
+    border: 1px solid #ccc;
+    padding: 0.5em 1em;
+}


### PR DESCRIPTION
## Summary
- implement static style and script files
- list encrypted files with countdown timer
- add decryption endpoint and download ability
- schedule deletion of encrypted files after 15 minutes

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686e4e26cfac832d8f3e128327992788